### PR TITLE
feat: add express server setup

### DIFF
--- a/src/interfaces/http/server.js
+++ b/src/interfaces/http/server.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const fs = require('fs');
+const path = require('path');
+
+function crearServidor() {
+  const app = express();
+
+  // Middlewares
+  app.use(cors());
+  app.use(helmet());
+  app.use(express.json());
+
+  // Cargar rutas
+  const rutasDir = path.join(__dirname, 'rutas');
+  if (fs.existsSync(rutasDir)) {
+    fs.readdirSync(rutasDir)
+      .filter((archivo) => archivo.endsWith('.ruta.js'))
+      .forEach((archivo) => {
+        const ruta = require(path.join(rutasDir, archivo));
+        const router = ruta.router || ruta.default || ruta;
+        if (router) {
+          app.use(router);
+        }
+      });
+  }
+
+  return app;
+}
+
+module.exports = { crearServidor };


### PR DESCRIPTION
## Summary
- create `crearServidor` in `interfaces/http/server.js`
- apply cors, helmet, and json middleware
- auto-load route modules from interfaces/http/rutas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4db82fc28832fb8652324d17a8dcc