### PR TITLE
feat: implement product CRUD with routes and server

### DIFF
--- a/src/applicacion/producto/crearProducto.js
+++ b/src/applicacion/producto/crearProducto.js
@@ -1,0 +1,14 @@
+// Caso de uso: crear un nuevo producto
+const { ProductoRepoSequelize } = require('../../infraestructura/repos/ProductoRepoSequelize');
+
+/**
+ * Crea un producto usando el repositorio de Sequelize
+ * @param {Object} datos Información del producto
+ * @returns {Promise<Object>} Producto creado
+ */
+async function crearProducto(datos) {
+  const repo = new ProductoRepoSequelize();
+  return repo.crear(datos);
+}
+
+module.exports = { crearProducto };

--- a/src/applicacion/producto/listarProducto.js
+++ b/src/applicacion/producto/listarProducto.js
@@ -1,0 +1,13 @@
+// Caso de uso: listar todos los productos
+const { ProductoRepoSequelize } = require('../../infraestructura/repos/ProductoRepoSequelize');
+
+/**
+ * Lista todos los productos existentes
+ * @returns {Promise<Array>} Lista de productos
+ */
+async function listarProducto() {
+  const repo = new ProductoRepoSequelize();
+  return repo.listar();
+}
+
+module.exports = { listarProducto };

--- a/src/applicacion/producto/obtenerProducto.js
+++ b/src/applicacion/producto/obtenerProducto.js
@@ -1,0 +1,14 @@
+// Caso de uso: obtener un producto por su ID
+const { ProductoRepoSequelize } = require('../../infraestructura/repos/ProductoRepoSequelize');
+
+/**
+ * Obtiene un producto
+ * @param {number} id Identificador del producto
+ * @returns {Promise<Object|null>} Producto encontrado o null
+ */
+async function obtenerProducto(id) {
+  const repo = new ProductoRepoSequelize();
+  return repo.obtenerPorId(id);
+}
+
+module.exports = { obtenerProducto };

--- a/src/infraestructura/repos/ProductoRepoSequelize.js
+++ b/src/infraestructura/repos/ProductoRepoSequelize.js
@@ -12,7 +12,26 @@ class ProductoRepoSequelize {
     });
     return p ? p.toJSON() : null;
   }
-  // ...
+  async listar() {
+    const productos = await db.Producto.findAll({
+      include: [
+        { model: db.Inventario, as: 'inventario' },
+        { model: db.Categoria, as: 'categoria' }
+      ]
+    });
+    return productos.map(p => p.toJSON());
+  }
+
+  async actualizar(id, datos) {
+    const [actualizados] = await db.Producto.update(datos, { where: { id } });
+    if (!actualizados) return null;
+    return this.obtenerPorId(id);
+  }
+
+  async eliminar(id) {
+    const eliminados = await db.Producto.destroy({ where: { id } });
+    return eliminados > 0;
+  }
 }
 
 module.exports = { ProductoRepoSequelize };

--- a/src/interfaces/http/controladores/producto.ctrl.js
+++ b/src/interfaces/http/controladores/producto.ctrl.js
@@ -1,0 +1,63 @@
+// Controladores HTTP para productos
+const { crearProducto } = require('../../../applicacion/producto/crearProducto');
+const { obtenerProducto } = require('../../../applicacion/producto/obtenerProducto');
+const { listarProducto } = require('../../../applicacion/producto/listarProducto');
+const { ProductoRepoSequelize } = require('../../../infraestructura/repos/ProductoRepoSequelize');
+
+async function crearProductoCtrl(req, res, next) {
+  try {
+    const producto = await crearProducto(req.body);
+    res.status(201).json(producto);
+  } catch (e) {
+    next(e);
+  }
+}
+
+async function obtenerProductoCtrl(req, res, next) {
+  try {
+    const producto = await obtenerProducto(req.params.id);
+    if (!producto) return res.status(404).json({ mensaje: 'Producto no encontrado' });
+    res.json(producto);
+  } catch (e) {
+    next(e);
+  }
+}
+
+async function listarProductoCtrl(req, res, next) {
+  try {
+    const productos = await listarProducto();
+    res.json(productos);
+  } catch (e) {
+    next(e);
+  }
+}
+
+async function actualizarProductoCtrl(req, res, next) {
+  try {
+    const repo = new ProductoRepoSequelize();
+    const producto = await repo.actualizar(req.params.id, req.body);
+    if (!producto) return res.status(404).json({ mensaje: 'Producto no encontrado' });
+    res.json(producto);
+  } catch (e) {
+    next(e);
+  }
+}
+
+async function eliminarProductoCtrl(req, res, next) {
+  try {
+    const repo = new ProductoRepoSequelize();
+    const eliminado = await repo.eliminar(req.params.id);
+    if (!eliminado) return res.status(404).json({ mensaje: 'Producto no encontrado' });
+    res.status(204).end();
+  } catch (e) {
+    next(e);
+  }
+}
+
+module.exports = {
+  crearProductoCtrl,
+  obtenerProductoCtrl,
+  listarProductoCtrl,
+  actualizarProductoCtrl,
+  eliminarProductoCtrl
+};

--- a/src/interfaces/http/rutas/producto.ruta.js
+++ b/src/interfaces/http/rutas/producto.ruta.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const {
+  crearProductoCtrl,
+  obtenerProductoCtrl,
+  listarProductoCtrl,
+  actualizarProductoCtrl,
+  eliminarProductoCtrl
+} = require('../controladores/producto.ctrl');
+
+const router = express.Router();
+
+router.post('/', crearProductoCtrl);
+router.get('/', listarProductoCtrl);
+router.get('/:id', obtenerProductoCtrl);
+router.put('/:id', actualizarProductoCtrl);
+router.delete('/:id', eliminarProductoCtrl);
+
+module.exports = router;

--- a/src/interfaces/http/server.js
+++ b/src/interfaces/http/server.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+
+const productoRuta = require('./rutas/producto.ruta');
+
+function crearServidor() {
+  const app = express();
+  app.use(cors());
+  app.use(helmet());
+  app.use(express.json());
+
+  // Registro de rutas
+  app.use('/api/productos', productoRuta);
+
+  // Manejador de errores simple
+  app.use((err, req, res, next) => {
+    console.error(err);
+    res.status(500).json({ mensaje: 'Error interno del servidor' });
+  });
+
+  return app;
+}
+
+module.exports = { crearServidor };
+


### PR DESCRIPTION
## Summary
- add use cases to create, fetch and list products
- implement Sequelize repository methods for listing, updating and deleting
- expose product CRUD endpoints via controllers and routes and register server

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4df4d8c40832f809db2c61981ff04