### PR TITLE
Add JWT auth endpoints and middleware

### DIFF
--- a/src/applicacion/usuario/auth.js
+++ b/src/applicacion/usuario/auth.js
@@ -1,0 +1,47 @@
+const crypto = require('crypto');
+
+const SECRET = process.env.JWT_SECRETO || 'secreto';
+
+function base64url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function generarToken(payload, expSegundos = 3600) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + expSegundos;
+  const data = { ...payload, exp };
+  const partes = [base64url(JSON.stringify(header)), base64url(JSON.stringify(data))];
+  const firma = crypto
+    .createHmac('sha256', SECRET)
+    .update(partes.join('.'))
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  partes.push(firma);
+  return partes.join('.');
+}
+
+function verificarToken(token) {
+  const [h, p, f] = token.split('.');
+  if (!h || !p || !f) throw new Error('Token inválido');
+  const firma = crypto
+    .createHmac('sha256', SECRET)
+    .update(`${h}.${p}`)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  if (firma !== f) throw new Error('Firma no válida');
+  const payload = JSON.parse(Buffer.from(p, 'base64').toString());
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    throw new Error('Token expirado');
+  }
+  return payload;
+}
+
+module.exports = { generarToken, verificarToken };

--- a/src/applicacion/usuario/iniciarSesion.js
+++ b/src/applicacion/usuario/iniciarSesion.js
@@ -1,0 +1,19 @@
+const bcrypt = require('bcryptjs');
+const db = require('../../infraestructura/orm/models');
+const { generarToken } = require('./auth');
+
+async function iniciarSesion({ email, password }) {
+  const { Usuario, Rol } = db;
+  const usuario = await Usuario.findOne({ where: { email }, include: { model: Rol, as: 'rol' } });
+  if (!usuario) {
+    throw new Error('Credenciales inválidas');
+  }
+  const valido = await bcrypt.compare(password, usuario.hash);
+  if (!valido) {
+    throw new Error('Credenciales inválidas');
+  }
+  const token = generarToken({ uid: usuario.id, rol: usuario.rol ? usuario.rol.nombre : null });
+  return { token };
+}
+
+module.exports = { iniciarSesion };

--- a/src/applicacion/usuario/registrarUsuario.js
+++ b/src/applicacion/usuario/registrarUsuario.js
@@ -1,0 +1,17 @@
+const bcrypt = require('bcryptjs');
+const db = require('../../infraestructura/orm/models');
+
+async function registrarUsuario({ nombre, email, password, rol = 'cliente' }) {
+  const { Usuario, Rol } = db;
+  const existente = await Usuario.findOne({ where: { email } });
+  if (existente) {
+    throw new Error('Email ya registrado');
+  }
+  const rolInst = await Rol.findOne({ where: { nombre: rol } });
+  const rolId = rolInst ? rolInst.id : null;
+  const hash = await bcrypt.hash(password, 10);
+  const usuario = await Usuario.create({ nombre, email, hash, rolId });
+  return { id: usuario.id, nombre: usuario.nombre, email: usuario.email, rol: rolInst ? rolInst.nombre : null };
+}
+
+module.exports = { registrarUsuario };

--- a/src/interfaces/http/controladores/auth.ctrl.js
+++ b/src/interfaces/http/controladores/auth.ctrl.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const { registrarUsuario } = require('../../../applicacion/usuario/registrarUsuario');
+const { iniciarSesion } = require('../../../applicacion/usuario/iniciarSesion');
+
+const router = express.Router();
+
+router.post('/registro', async (req, res, next) => {
+  try {
+    const usuario = await registrarUsuario(req.body);
+    res.status(201).json(usuario);
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.post('/login', async (req, res, next) => {
+  try {
+    const resultado = await iniciarSesion(req.body);
+    res.json(resultado);
+  } catch (e) {
+    next(e);
+  }
+});
+
+module.exports = router;

--- a/src/interfaces/http/middlewares/esAdmin.js
+++ b/src/interfaces/http/middlewares/esAdmin.js
@@ -1,0 +1,8 @@
+function esAdmin(req, res, next) {
+  if (req.usuario && req.usuario.rol === 'admin') {
+    return next();
+  }
+  return res.status(403).json({ error: 'Acceso denegado' });
+}
+
+module.exports = { esAdmin };

--- a/src/interfaces/http/middlewares/validarJWT.js
+++ b/src/interfaces/http/middlewares/validarJWT.js
@@ -1,0 +1,18 @@
+const { verificarToken } = require('../../../applicacion/usuario/auth');
+
+function validarJWT(req, res, next) {
+  const auth = req.headers['authorization'] || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+  if (!token) {
+    return res.status(401).json({ error: 'Token requerido' });
+  }
+  try {
+    const payload = verificarToken(token);
+    req.usuario = payload;
+    next();
+  } catch (e) {
+    return res.status(401).json({ error: 'Token inválido' });
+  }
+}
+
+module.exports = { validarJWT };

--- a/src/interfaces/http/rutas/auth.ruta.js
+++ b/src/interfaces/http/rutas/auth.ruta.js
@@ -1,0 +1,1 @@
+module.exports = require('../controladores/auth.ctrl');


### PR DESCRIPTION
## Summary
- Implement user registration and login endpoints
- Add custom JWT generation/verification service
- Include middlewares for token validation and admin role restriction

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4e4372908832fbee966c1ccca09d8