### PR TITLE
feat: implement order use cases and routes

### DIFF
--- a/src/applicacion/pedido/cancelarPedido.js
+++ b/src/applicacion/pedido/cancelarPedido.js
@@ -1,0 +1,21 @@
+const { pedidos, inventario } = require('./repositorioMemoria');
+
+/**
+ * Cancela un pedido existente y restaura el stock de inventario.
+ * @param {number} pedidoId - Identificador del pedido.
+ * @returns {Object|null} Pedido cancelado o null si no existe.
+ */
+function cancelarPedido(pedidoId) {
+  const pedido = pedidos.find((p) => p.id === Number(pedidoId));
+  if (!pedido || pedido.estado === 'cancelado') {
+    return null;
+  }
+
+  pedido.estado = 'cancelado';
+  for (const { productoId, cantidad } of pedido.items) {
+    inventario[productoId] = (inventario[productoId] || 0) + cantidad;
+  }
+  return pedido;
+}
+
+module.exports = cancelarPedido;

--- a/src/applicacion/pedido/crearPedido.js
+++ b/src/applicacion/pedido/crearPedido.js
@@ -1,0 +1,43 @@
+const { inventario, pedidos, generarId } = require('./repositorioMemoria');
+
+/**
+ * Crea un nuevo pedido para un usuario y descuenta el stock de los productos.
+ * @param {Object} datos - Datos del pedido.
+ * @param {number} datos.usuarioId - Identificador del usuario.
+ * @param {Array<{productoId:number,cantidad:number}>} datos.items - Productos solicitados.
+ * @returns {Object} Pedido creado.
+ */
+function crearPedido({ usuarioId, items }) {
+  if (!usuarioId) {
+    throw new Error('usuarioId es requerido');
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error('items es requerido');
+  }
+
+  // Verificar stock disponible
+  for (const { productoId, cantidad } of items) {
+    const stock = inventario[productoId] || 0;
+    if (cantidad > stock) {
+      throw new Error(`Stock insuficiente para el producto ${productoId}`);
+    }
+  }
+
+  // Descontar stock
+  for (const { productoId, cantidad } of items) {
+    inventario[productoId] = (inventario[productoId] || 0) - cantidad;
+  }
+
+  const pedido = {
+    id: generarId(),
+    usuarioId,
+    items: items.map((i) => ({ ...i })),
+    estado: 'creado',
+    creadoEn: new Date(),
+  };
+
+  pedidos.push(pedido);
+  return pedido;
+}
+
+module.exports = crearPedido;

--- a/src/applicacion/pedido/historialPedidos.js
+++ b/src/applicacion/pedido/historialPedidos.js
@@ -1,0 +1,12 @@
+const { pedidos } = require('./repositorioMemoria');
+
+/**
+ * Devuelve el historial de pedidos de un usuario.
+ * @param {number} usuarioId - Identificador del usuario.
+ * @returns {Array<Object>} Lista de pedidos del usuario.
+ */
+function historialPedidos(usuarioId) {
+  return pedidos.filter((p) => p.usuarioId === usuarioId);
+}
+
+module.exports = historialPedidos;

--- a/src/applicacion/pedido/repositorioMemoria.js
+++ b/src/applicacion/pedido/repositorioMemoria.js
@@ -1,0 +1,14 @@
+const inventario = {};
+const pedidos = [];
+let ultimoId = 0;
+
+function generarId() {
+  ultimoId += 1;
+  return ultimoId;
+}
+
+module.exports = {
+  inventario,
+  pedidos,
+  generarId,
+};

--- a/src/interfaces/http/controladores/pedido.ctrl.js
+++ b/src/interfaces/http/controladores/pedido.ctrl.js
@@ -1,0 +1,32 @@
+const crearPedido = require('../../../applicacion/pedido/crearPedido');
+const historialPedidos = require('../../../applicacion/pedido/historialPedidos');
+const cancelarPedido = require('../../../applicacion/pedido/cancelarPedido');
+
+async function realizarPedido(req, res) {
+  try {
+    const pedido = crearPedido(req.body);
+    res.status(201).json(pedido);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function obtenerHistorial(req, res) {
+  const usuarioId = Number(req.params.usuarioId || req.query.usuarioId);
+  const pedidos = historialPedidos(usuarioId);
+  res.json(pedidos);
+}
+
+async function cancelar(req, res) {
+  const pedido = cancelarPedido(req.params.id);
+  if (!pedido) {
+    return res.status(404).json({ error: 'Pedido no encontrado' });
+  }
+  res.json(pedido);
+}
+
+module.exports = {
+  realizarPedido,
+  obtenerHistorial,
+  cancelar,
+};

--- a/src/interfaces/http/rutas/pedido.ruta.js
+++ b/src/interfaces/http/rutas/pedido.ruta.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const pedidoCtrl = require('../controladores/pedido.ctrl');
+
+// Crear un pedido
+router.post('/', pedidoCtrl.realizarPedido);
+
+// Historial de pedidos de un usuario
+router.get('/:usuarioId', pedidoCtrl.obtenerHistorial);
+
+// Cancelar un pedido
+router.delete('/:id', pedidoCtrl.cancelar);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add in-memory repository and use cases for creating, cancelling, and listing orders
- hook up controllers and routes so users can place orders and view history
- adjust inventory when orders are created or cancelled

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c4ef6dd5dc832f899cf2cd0b0a73de