### PR TITLE
refactor: simplify server setup

### DIFF
--- a/src/interfaces/http/server.js
+++ b/src/interfaces/http/server.js
@@ -1,70 +1,26 @@
 const express = require('express');
 const cors = require('cors');
-
-const productoCtrl = require('./controladores/producto.ctrl');
-const authCtrl = require('./controladores/auth.ctrl');
-const pedidoCtrl = require('./controladores/pedido.ctrl');
-const manejarErrores = require('./middlewares/manejarErrores');
-
-function crearServidor() {
-  const app = express();
-  app.use(cors());
-  app.use(express.json());
-
-  app.post('/api/productos', productoCtrl.crear);
-  app.get('/api/productos', productoCtrl.listar);
-  app.get('/api/productos/:id', productoCtrl.obtener);
-
-  app.post('/api/auth/registro', authCtrl.registrar);
-  app.post('/api/auth/login', authCtrl.iniciar);
-
-  app.post('/api/pedidos', pedidoCtrl.crear);
-
-  app.use(manejarErrores);
-
 const helmet = require('helmet');
 
-
 const productoRuta = require('./rutas/producto.ruta');
+const authRuta = require('./rutas/auth.ruta');
+const pedidoRuta = require('./rutas/pedido.ruta');
 
 function crearServidor() {
   const app = express();
-
-const fs = require('fs');
-const path = require('path');
-
-function crearServidor() {
-  const app = express();
-
 
   app.use(cors());
   app.use(helmet());
   app.use(express.json());
 
-
-  // Registro de rutas
   app.use('/api/productos', productoRuta);
+  app.use('/api/auth', authRuta);
+  app.use('/api/pedidos', pedidoRuta);
 
-  // Manejador de errores simple
   app.use((err, req, res, next) => {
     console.error(err);
     res.status(500).json({ mensaje: 'Error interno del servidor' });
   });
-
-  // Cargar rutas
-  const rutasDir = path.join(__dirname, 'rutas');
-  if (fs.existsSync(rutasDir)) {
-    fs.readdirSync(rutasDir)
-      .filter((archivo) => archivo.endsWith('.ruta.js'))
-      .forEach((archivo) => {
-        const ruta = require(path.join(rutasDir, archivo));
-        const router = ruta.router || ruta.default || ruta;
-        if (router) {
-          app.use(router);
-        }
-      });
-  }
-
 
   return app;
 }


### PR DESCRIPTION
## Summary
- simplify HTTP server by consolidating to a single `crearServidor`
- import only necessary dependencies and register routes once

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c506792be8832fb85e36a8cbd02693