### PR TITLE
refactor: unify product controller exports

### DIFF
--- a/src/interfaces/http/controladores/producto.ctrl.js
+++ b/src/interfaces/http/controladores/producto.ctrl.js
@@ -1,7 +1,7 @@
-
 const crearProductoUC = require('../../../applicacion/producto/crearProducto');
 const listarProductoUC = require('../../../applicacion/producto/listarProducto');
 const obtenerProductoUC = require('../../../applicacion/producto/obtenerProducto');
+const { ProductoRepoSequelize } = require('../../../infraestructura/repos/ProductoRepoSequelize');
 const { productoSchema } = require('../validadores/producto.val');
 
 async function crear(req, res, next) {
@@ -33,69 +33,27 @@ async function obtener(req, res, next) {
   }
 }
 
-module.exports = { crear, listar, obtener };
-
-// Controladores HTTP para productos
-const { crearProducto } = require('../../../applicacion/producto/crearProducto');
-const { obtenerProducto } = require('../../../applicacion/producto/obtenerProducto');
-const { listarProducto } = require('../../../applicacion/producto/listarProducto');
-const { ProductoRepoSequelize } = require('../../../infraestructura/repos/ProductoRepoSequelize');
-
-async function crearProductoCtrl(req, res, next) {
-  try {
-    const producto = await crearProducto(req.body);
-    res.status(201).json(producto);
-  } catch (e) {
-    next(e);
-  }
-}
-
-async function obtenerProductoCtrl(req, res, next) {
-  try {
-    const producto = await obtenerProducto(req.params.id);
-    if (!producto) return res.status(404).json({ mensaje: 'Producto no encontrado' });
-    res.json(producto);
-  } catch (e) {
-    next(e);
-  }
-}
-
-async function listarProductoCtrl(req, res, next) {
-  try {
-    const productos = await listarProducto();
-    res.json(productos);
-  } catch (e) {
-    next(e);
-  }
-}
-
-async function actualizarProductoCtrl(req, res, next) {
+async function actualizar(req, res, next) {
   try {
     const repo = new ProductoRepoSequelize();
     const producto = await repo.actualizar(req.params.id, req.body);
     if (!producto) return res.status(404).json({ mensaje: 'Producto no encontrado' });
     res.json(producto);
-  } catch (e) {
-    next(e);
+  } catch (err) {
+    next(err);
   }
 }
 
-async function eliminarProductoCtrl(req, res, next) {
+async function eliminar(req, res, next) {
   try {
     const repo = new ProductoRepoSequelize();
     const eliminado = await repo.eliminar(req.params.id);
     if (!eliminado) return res.status(404).json({ mensaje: 'Producto no encontrado' });
     res.status(204).end();
-  } catch (e) {
-    next(e);
+  } catch (err) {
+    next(err);
   }
 }
 
-module.exports = {
-  crearProductoCtrl,
-  obtenerProductoCtrl,
-  listarProductoCtrl,
-  actualizarProductoCtrl,
-  eliminarProductoCtrl
-};
+module.exports = { crear, listar, obtener, actualizar, eliminar };
 

--- a/src/interfaces/http/rutas/producto.ruta.js
+++ b/src/interfaces/http/rutas/producto.ruta.js
@@ -1,18 +1,18 @@
 const express = require('express');
 const {
-  crearProductoCtrl,
-  obtenerProductoCtrl,
-  listarProductoCtrl,
-  actualizarProductoCtrl,
-  eliminarProductoCtrl
+  crear,
+  listar,
+  obtener,
+  actualizar,
+  eliminar,
 } = require('../controladores/producto.ctrl');
 
 const router = express.Router();
 
-router.post('/', crearProductoCtrl);
-router.get('/', listarProductoCtrl);
-router.get('/:id', obtenerProductoCtrl);
-router.put('/:id', actualizarProductoCtrl);
-router.delete('/:id', eliminarProductoCtrl);
+router.post('/', crear);
+router.get('/', listar);
+router.get('/:id', obtener);
+router.put('/:id', actualizar);
+router.delete('/:id', eliminar);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- consolidate product controllers into a single CRUD module
- update product routes to use final controller names

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5073813c8832fbdd68493e4561a61