### PR TITLE
refactor: separate auth router

### DIFF
--- a/src/interfaces/http/controladores/auth.ctrl.js
+++ b/src/interfaces/http/controladores/auth.ctrl.js
@@ -24,29 +24,3 @@ async function iniciar(req, res, next) {
 }
 
 module.exports = { registrar, iniciar };
-
-const express = require('express');
-const { registrarUsuario } = require('../../../applicacion/usuario/registrarUsuario');
-const { iniciarSesion } = require('../../../applicacion/usuario/iniciarSesion');
-
-const router = express.Router();
-
-router.post('/registro', async (req, res, next) => {
-  try {
-    const usuario = await registrarUsuario(req.body);
-    res.status(201).json(usuario);
-  } catch (e) {
-    next(e);
-  }
-});
-
-router.post('/login', async (req, res, next) => {
-  try {
-    const resultado = await iniciarSesion(req.body);
-    res.json(resultado);
-  } catch (e) {
-    next(e);
-  }
-});
-
-module.exports = router;

--- a/src/interfaces/http/rutas/auth.ruta.js
+++ b/src/interfaces/http/rutas/auth.ruta.js
@@ -1,1 +1,10 @@
-module.exports = require('../controladores/auth.ctrl');
+const express = require('express');
+const { registrar, iniciar } = require('../controladores/auth.ctrl');
+
+const router = express.Router();
+
+router.post('/registro', registrar);
+router.post('/login', iniciar);
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- keep registrar and iniciar only in controller
- add dedicated auth router building from those handlers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5094fcb90832f876fd755ca6ad265