### PR TITLE
Remove placeholder exports from user auth handlers

### DIFF
--- a/src/applicacion/usuario/iniciarSesion.js
+++ b/src/applicacion/usuario/iniciarSesion.js
@@ -1,8 +1,4 @@
 
-module.exports = async function iniciarSesion(datos) {
-  return { token: 'fake-token', ...datos };
-};
-
 const bcrypt = require('bcryptjs');
 const db = require('../../infraestructura/orm/models');
 const { generarToken } = require('./auth');
@@ -21,4 +17,4 @@ async function iniciarSesion({ email, password }) {
   return { token };
 }
 
-module.exports = { iniciarSesion };
+module.exports = iniciarSesion;

--- a/src/applicacion/usuario/registrarUsuario.js
+++ b/src/applicacion/usuario/registrarUsuario.js
@@ -1,8 +1,4 @@
 
-module.exports = async function registrarUsuario(datos) {
-  return { id: 1, ...datos };
-};
-
 const bcrypt = require('bcryptjs');
 const db = require('../../infraestructura/orm/models');
 
@@ -19,5 +15,5 @@ async function registrarUsuario({ nombre, email, password, rol = 'cliente' }) {
   return { id: usuario.id, nombre: usuario.nombre, email: usuario.email, rol: rolInst ? rolInst.nombre : null };
 }
 
-module.exports = { registrarUsuario };
+module.exports = registrarUsuario;
 


### PR DESCRIPTION
## Summary
- remove placeholder mock exports from registrarUsuario and iniciarSesion
- export only the implemented functions for user registration and login

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c50a26c700832f96b0f4d92d4def10