### PR TITLE
Fix pedido controller to match routes

### DIFF
--- a/src/interfaces/http/controladores/pedido.ctrl.js
+++ b/src/interfaces/http/controladores/pedido.ctrl.js
@@ -30,18 +30,3 @@ module.exports = {
   obtenerHistorial,
   cancelar,
 };
-=======
-const crearPedidoUC = require('../../../applicacion/pedido/crearPedido');
-const { pedidoSchema } = require('../validadores/pedido.val');
-
-async function crear(req, res, next) {
-  try {
-    const datos = pedidoSchema.parse(req.body);
-    const resultado = await crearPedidoUC(datos);
-    res.status(201).json(resultado);
-  } catch (err) {
-    next(err);
-  }
-}
-
-module.exports = { crear };


### PR DESCRIPTION
## Summary
- remove duplicate create-only pedido controller block
- export full CRUD functions used by pedido routes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c50ba06da0832fad2d9d8f46c7c47c