### PR TITLE
Remove mock order creator export

### DIFF
--- a/src/applicacion/pedido/crearPedido.js
+++ b/src/applicacion/pedido/crearPedido.js
@@ -42,7 +42,3 @@ function crearPedido({ usuarioId, items }) {
 
 module.exports = crearPedido;
 
-module.exports = async function crearPedido(datos) {
-  return { id: 1, ...datos };
-};
-


### PR DESCRIPTION
## Summary
- remove leftover mock order creator export in pedido module
- ensure only real crearPedido function managing inventory is exported

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c50c55c704832fbfe15a76a36e26a6