### PR TITLE
Protect routes with JWT and admin middleware

### DIFF
--- a/PRUEBAS_MANUALES.md
+++ b/PRUEBAS_MANUALES.md
@@ -1,0 +1,21 @@
+# Pruebas manuales de protección de rutas
+
+Las rutas protegidas requieren un encabezado `Authorization` con un token JWT válido:
+
+```
+Authorization: Bearer <token>
+```
+
+## Pedidos
+- `POST /api/pedidos` requiere JWT.
+- `GET /api/pedidos/:usuarioId` requiere JWT.
+- `DELETE /api/pedidos/:id` requiere JWT.
+
+## Productos (solo administradores)
+Las siguientes rutas requieren un token de un usuario con `rol` **admin**:
+- `POST /api/productos`
+- `PUT /api/productos/:id`
+- `DELETE /api/productos/:id`
+
+Las rutas `GET /api/productos` y `GET /api/productos/:id` no requieren autenticación.
+

--- a/src/interfaces/http/rutas/pedido.ruta.js
+++ b/src/interfaces/http/rutas/pedido.ruta.js
@@ -1,14 +1,15 @@
 const express = require('express');
 const router = express.Router();
 const pedidoCtrl = require('../controladores/pedido.ctrl');
+const { validarJWT } = require('../middlewares/validarJWT');
 
 // Crear un pedido
-router.post('/', pedidoCtrl.realizarPedido);
+router.post('/', validarJWT, pedidoCtrl.realizarPedido);
 
 // Historial de pedidos de un usuario
-router.get('/:usuarioId', pedidoCtrl.obtenerHistorial);
+router.get('/:usuarioId', validarJWT, pedidoCtrl.obtenerHistorial);
 
 // Cancelar un pedido
-router.delete('/:id', pedidoCtrl.cancelar);
+router.delete('/:id', validarJWT, pedidoCtrl.cancelar);
 
 module.exports = router;

--- a/src/interfaces/http/rutas/producto.ruta.js
+++ b/src/interfaces/http/rutas/producto.ruta.js
@@ -6,13 +6,15 @@ const {
   actualizar,
   eliminar,
 } = require('../controladores/producto.ctrl');
+const { validarJWT } = require('../middlewares/validarJWT');
+const { esAdmin } = require('../middlewares/esAdmin');
 
 const router = express.Router();
 
-router.post('/', crear);
+router.post('/', validarJWT, esAdmin, crear);
 router.get('/', listar);
 router.get('/:id', obtener);
-router.put('/:id', actualizar);
-router.delete('/:id', eliminar);
+router.put('/:id', validarJWT, esAdmin, actualizar);
+router.delete('/:id', validarJWT, esAdmin, eliminar);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- secure order routes with JWT middleware
- require JWT and admin role for product creation, update and deletion
- document protected endpoints and manual testing steps

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c50ee4d4f4832fa47b522efea06138