### PR TITLE
Add shared enums and application error classes

### DIFF
--- a/src/applicacion/comun/Excepciones.js
+++ b/src/applicacion/comun/Excepciones.js
@@ -1,0 +1,25 @@
+class ErrorDeAplicacion extends Error {
+  constructor(mensaje, codigo = 500) {
+    super(mensaje);
+    this.name = this.constructor.name;
+    this.codigo = codigo;
+  }
+}
+
+class RecursoNoEncontrado extends ErrorDeAplicacion {
+  constructor(mensaje = 'Recurso no encontrado') {
+    super(mensaje, 404);
+  }
+}
+
+class ErrorDeValidacion extends ErrorDeAplicacion {
+  constructor(mensaje = 'Datos inválidos') {
+    super(mensaje, 400);
+  }
+}
+
+module.exports = {
+  ErrorDeAplicacion,
+  RecursoNoEncontrado,
+  ErrorDeValidacion,
+};

--- a/src/applicacion/comun/Tipos.js
+++ b/src/applicacion/comun/Tipos.js
@@ -1,0 +1,14 @@
+const ESTADO_PEDIDO = Object.freeze({
+  CREADO: 'creado',
+  CANCELADO: 'cancelado',
+});
+
+const ROLES_USUARIO = Object.freeze({
+  ADMIN: 'admin',
+  CLIENTE: 'cliente',
+});
+
+module.exports = {
+  ESTADO_PEDIDO,
+  ROLES_USUARIO,
+};

--- a/src/applicacion/pedido/cancelarPedido.js
+++ b/src/applicacion/pedido/cancelarPedido.js
@@ -1,4 +1,5 @@
 const { pedidos, inventario } = require('./repositorioMemoria');
+const { ESTADO_PEDIDO } = require('../comun/Tipos');
 
 /**
  * Cancela un pedido existente y restaura el stock de inventario.
@@ -7,11 +8,11 @@ const { pedidos, inventario } = require('./repositorioMemoria');
  */
 function cancelarPedido(pedidoId) {
   const pedido = pedidos.find((p) => p.id === Number(pedidoId));
-  if (!pedido || pedido.estado === 'cancelado') {
+  if (!pedido || pedido.estado === ESTADO_PEDIDO.CANCELADO) {
     return null;
   }
 
-  pedido.estado = 'cancelado';
+  pedido.estado = ESTADO_PEDIDO.CANCELADO;
   for (const { productoId, cantidad } of pedido.items) {
     inventario[productoId] = (inventario[productoId] || 0) + cantidad;
   }

--- a/src/applicacion/pedido/crearPedido.js
+++ b/src/applicacion/pedido/crearPedido.js
@@ -1,4 +1,6 @@
 const { inventario, pedidos, generarId } = require('./repositorioMemoria');
+const { ESTADO_PEDIDO } = require('../comun/Tipos');
+const { ErrorDeValidacion } = require('../comun/Excepciones');
 
 /**
  * Crea un nuevo pedido para un usuario y descuenta el stock de los productos.
@@ -9,17 +11,17 @@ const { inventario, pedidos, generarId } = require('./repositorioMemoria');
  */
 function crearPedido({ usuarioId, items }) {
   if (!usuarioId) {
-    throw new Error('usuarioId es requerido');
+    throw new ErrorDeValidacion('usuarioId es requerido');
   }
   if (!Array.isArray(items) || items.length === 0) {
-    throw new Error('items es requerido');
+    throw new ErrorDeValidacion('items es requerido');
   }
 
   // Verificar stock disponible
   for (const { productoId, cantidad } of items) {
     const stock = inventario[productoId] || 0;
     if (cantidad > stock) {
-      throw new Error(`Stock insuficiente para el producto ${productoId}`);
+      throw new ErrorDeValidacion(`Stock insuficiente para el producto ${productoId}`);
     }
   }
 
@@ -32,7 +34,7 @@ function crearPedido({ usuarioId, items }) {
     id: generarId(),
     usuarioId,
     items: items.map((i) => ({ ...i })),
-    estado: 'creado',
+    estado: ESTADO_PEDIDO.CREADO,
     creadoEn: new Date(),
   };
 
@@ -41,4 +43,3 @@ function crearPedido({ usuarioId, items }) {
 }
 
 module.exports = crearPedido;
-

--- a/src/applicacion/usuario/auth.js
+++ b/src/applicacion/usuario/auth.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { ErrorDeAplicacion } = require('../comun/Excepciones');
 
 const SECRET = process.env.JWT_SECRETO || 'secreto';
 
@@ -28,7 +29,7 @@ function generarToken(payload, expSegundos = 3600) {
 
 function verificarToken(token) {
   const [h, p, f] = token.split('.');
-  if (!h || !p || !f) throw new Error('Token inválido');
+  if (!h || !p || !f) throw new ErrorDeAplicacion('Token inválido', 401);
   const firma = crypto
     .createHmac('sha256', SECRET)
     .update(`${h}.${p}`)
@@ -36,10 +37,10 @@ function verificarToken(token) {
     .replace(/=/g, '')
     .replace(/\+/g, '-')
     .replace(/\//g, '_');
-  if (firma !== f) throw new Error('Firma no válida');
+  if (firma !== f) throw new ErrorDeAplicacion('Firma no válida', 401);
   const payload = JSON.parse(Buffer.from(p, 'base64').toString());
   if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
-    throw new Error('Token expirado');
+    throw new ErrorDeAplicacion('Token expirado', 401);
   }
   return payload;
 }

--- a/src/applicacion/usuario/iniciarSesion.js
+++ b/src/applicacion/usuario/iniciarSesion.js
@@ -1,17 +1,17 @@
-
 const bcrypt = require('bcryptjs');
 const db = require('../../infraestructura/orm/models');
 const { generarToken } = require('./auth');
+const { ErrorDeAplicacion } = require('../comun/Excepciones');
 
 async function iniciarSesion({ email, password }) {
   const { Usuario, Rol } = db;
   const usuario = await Usuario.findOne({ where: { email }, include: { model: Rol, as: 'rol' } });
   if (!usuario) {
-    throw new Error('Credenciales inválidas');
+    throw new ErrorDeAplicacion('Credenciales inválidas', 401);
   }
   const valido = await bcrypt.compare(password, usuario.hash);
   if (!valido) {
-    throw new Error('Credenciales inválidas');
+    throw new ErrorDeAplicacion('Credenciales inválidas', 401);
   }
   const token = generarToken({ uid: usuario.id, rol: usuario.rol ? usuario.rol.nombre : null });
   return { token };

--- a/src/applicacion/usuario/registrarUsuario.js
+++ b/src/applicacion/usuario/registrarUsuario.js
@@ -1,12 +1,13 @@
-
 const bcrypt = require('bcryptjs');
 const db = require('../../infraestructura/orm/models');
+const { ROLES_USUARIO } = require('../comun/Tipos');
+const { ErrorDeAplicacion } = require('../comun/Excepciones');
 
-async function registrarUsuario({ nombre, email, password, rol = 'cliente' }) {
+async function registrarUsuario({ nombre, email, password, rol = ROLES_USUARIO.CLIENTE }) {
   const { Usuario, Rol } = db;
   const existente = await Usuario.findOne({ where: { email } });
   if (existente) {
-    throw new Error('Email ya registrado');
+    throw new ErrorDeAplicacion('Email ya registrado', 409);
   }
   const rolInst = await Rol.findOne({ where: { nombre: rol } });
   const rolId = rolInst ? rolInst.id : null;
@@ -16,4 +17,3 @@ async function registrarUsuario({ nombre, email, password, rol = 'cliente' }) {
 }
 
 module.exports = registrarUsuario;
-

--- a/src/dominio/entidades/Pedido.js
+++ b/src/dominio/entidades/Pedido.js
@@ -1,14 +1,17 @@
+const { ESTADO_PEDIDO } = require('../../applicacion/comun/Tipos');
+const { ErrorDeValidacion } = require('../../applicacion/comun/Excepciones');
+
 class Pedido {
-  constructor({ id = null, usuarioId, items, estado = 'creado', creadoEn = new Date() }) {
+  constructor({ id = null, usuarioId, items, estado = ESTADO_PEDIDO.CREADO, creadoEn = new Date() }) {
     if (!usuarioId) {
-      throw new Error('usuarioId requerido');
+      throw new ErrorDeValidacion('usuarioId requerido');
     }
     if (!Array.isArray(items) || items.length === 0) {
-      throw new Error('items es requerido');
+      throw new ErrorDeValidacion('items es requerido');
     }
     for (const item of items) {
       if (!item.productoId || typeof item.cantidad !== 'number' || item.cantidad <= 0) {
-        throw new Error('Item de pedido inválido');
+        throw new ErrorDeValidacion('Item de pedido inválido');
       }
     }
     this.id = id;
@@ -19,8 +22,8 @@ class Pedido {
   }
 
   cancelar() {
-    if (this.estado !== 'cancelado') {
-      this.estado = 'cancelado';
+    if (this.estado !== ESTADO_PEDIDO.CANCELADO) {
+      this.estado = ESTADO_PEDIDO.CANCELADO;
     }
   }
 

--- a/src/dominio/entidades/Producto.js
+++ b/src/dominio/entidades/Producto.js
@@ -1,10 +1,12 @@
+const { ErrorDeValidacion } = require('../../applicacion/comun/Excepciones');
+
 class Producto {
   constructor({ id = null, nombre, descripcion = null, precio, activo = true, categoriaId = null, categoria = null, inventario = null }) {
     if (!nombre) {
-      throw new Error('Nombre requerido');
+      throw new ErrorDeValidacion('Nombre requerido');
     }
     if (typeof precio !== 'number' || precio <= 0) {
-      throw new Error('Precio debe ser positivo');
+      throw new ErrorDeValidacion('Precio debe ser positivo');
     }
     this.id = id;
     this.nombre = nombre;

--- a/src/dominio/entidades/Usuario.js
+++ b/src/dominio/entidades/Usuario.js
@@ -1,14 +1,16 @@
+const { ErrorDeValidacion } = require('../../applicacion/comun/Excepciones');
+
 class Usuario {
   constructor({ id = null, nombre, email, hash, rolId = null, rol = null }) {
     if (!nombre) {
-      throw new Error('Nombre requerido');
+      throw new ErrorDeValidacion('Nombre requerido');
     }
     const emailRegex = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
     if (!email || !emailRegex.test(email)) {
-      throw new Error('Email inválido');
+      throw new ErrorDeValidacion('Email inválido');
     }
     if (!hash) {
-      throw new Error('Hash requerido');
+      throw new ErrorDeValidacion('Hash requerido');
     }
     this.id = id;
     this.nombre = nombre;

--- a/src/infraestructura/repos/PedidoRepoSequelize.js
+++ b/src/infraestructura/repos/PedidoRepoSequelize.js
@@ -1,4 +1,5 @@
 const Pedido = require('../../dominio/entidades/Pedido');
+const { ESTADO_PEDIDO } = require('../../applicacion/comun/Tipos');
 
 let pedidos = [];
 let ultimoId = 0;
@@ -20,7 +21,7 @@ class PedidoRepoSequelize {
 
   async cancelar(id) {
     const pedido = await this.obtenerPorId(id);
-    if (!pedido || pedido.estado === 'cancelado') {
+    if (!pedido || pedido.estado === ESTADO_PEDIDO.CANCELADO) {
       return null;
     }
     pedido.cancelar();

--- a/src/interfaces/http/middlewares/esAdmin.js
+++ b/src/interfaces/http/middlewares/esAdmin.js
@@ -1,5 +1,7 @@
+const { ROLES_USUARIO } = require('../../applicacion/comun/Tipos');
+
 function esAdmin(req, res, next) {
-  if (req.usuario && req.usuario.rol === 'admin') {
+  if (req.usuario && req.usuario.rol === ROLES_USUARIO.ADMIN) {
     return next();
   }
   return res.status(403).json({ error: 'Acceso denegado' });


### PR DESCRIPTION
## Summary
- Define shared `ESTADO_PEDIDO` and `ROLES_USUARIO` enums
- Add custom `ErrorDeAplicacion`, `RecursoNoEncontrado` and `ErrorDeValidacion` with HTTP codes
- Replace hardcoded strings and default errors across modules

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c73ec8b418832fb2980db633bc7fdd