### PR TITLE
Usar middleware de manejo de errores

### DIFF
--- a/src/interfaces/http/controladores/pedido.ctrl.js
+++ b/src/interfaces/http/controladores/pedido.ctrl.js
@@ -2,27 +2,35 @@ const crearPedido = require('../../../applicacion/pedido/crearPedido');
 const historialPedidos = require('../../../applicacion/pedido/historialPedidos');
 const cancelarPedido = require('../../../applicacion/pedido/cancelarPedido');
 
-async function realizarPedido(req, res) {
+async function realizarPedido(req, res, next) {
   try {
     const pedido = crearPedido(req.body);
     res.status(201).json(pedido);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    next(err);
   }
 }
 
-async function obtenerHistorial(req, res) {
-  const usuarioId = Number(req.params.usuarioId || req.query.usuarioId);
-  const pedidos = historialPedidos(usuarioId);
-  res.json(pedidos);
+async function obtenerHistorial(req, res, next) {
+  try {
+    const usuarioId = Number(req.params.usuarioId || req.query.usuarioId);
+    const pedidos = historialPedidos(usuarioId);
+    res.json(pedidos);
+  } catch (err) {
+    next(err);
+  }
 }
 
-async function cancelar(req, res) {
-  const pedido = cancelarPedido(req.params.id);
-  if (!pedido) {
-    return res.status(404).json({ error: 'Pedido no encontrado' });
+async function cancelar(req, res, next) {
+  try {
+    const pedido = cancelarPedido(req.params.id);
+    if (!pedido) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+    res.json(pedido);
+  } catch (err) {
+    next(err);
   }
-  res.json(pedido);
 }
 
 module.exports = {

--- a/src/interfaces/http/server.js
+++ b/src/interfaces/http/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 
+const manejarErrores = require('./middlewares/manejarErrores');
 const productoRuta = require('./rutas/producto.ruta');
 const authRuta = require('./rutas/auth.ruta');
 const pedidoRuta = require('./rutas/pedido.ruta');
@@ -17,10 +18,7 @@ function crearServidor() {
   app.use('/api/auth', authRuta);
   app.use('/api/pedidos', pedidoRuta);
 
-  app.use((err, req, res, next) => {
-    console.error(err);
-    res.status(500).json({ mensaje: 'Error interno del servidor' });
-  });
+  app.use(manejarErrores);
 
   return app;
 }


### PR DESCRIPTION
## Resumen
- Importa y registra el middleware `manejarErrores` en el servidor HTTP.
- Ajusta los controladores de pedidos para delegar fallos a `next(err)` y aprovechar el middleware.

## Testing
- `npm test` (falla: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c7464be9d8832f9ea92f50027f6c93