### PR TITLE
Validate order payload and propagate controller errors

### DIFF
--- a/src/interfaces/http/controladores/pedido.ctrl.js
+++ b/src/interfaces/http/controladores/pedido.ctrl.js
@@ -1,10 +1,12 @@
 const crearPedido = require('../../../applicacion/pedido/crearPedido');
 const historialPedidos = require('../../../applicacion/pedido/historialPedidos');
 const cancelarPedido = require('../../../applicacion/pedido/cancelarPedido');
+const { pedidoSchema } = require('../validadores/pedido.val');
 
 async function realizarPedido(req, res, next) {
   try {
-    const pedido = crearPedido(req.body);
+    const datos = pedidoSchema.parse(req.body);
+    const pedido = crearPedido(datos);
     res.status(201).json(pedido);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- validate `realizarPedido` requests with `pedidoSchema`
- ensure `realizarPedido`, `obtenerHistorial`, and `cancelar` forward errors via `next`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7550b9d00832fbcfdf3854e59e465