### PR TITLE
refactor: renombra variables de pedido

### DIFF
--- a/src/interfaces/http/controladores/pedido.ctrl.js
+++ b/src/interfaces/http/controladores/pedido.ctrl.js
@@ -5,13 +5,9 @@ const { pedidoSchema } = require('../validadores/pedido.val');
 
 async function realizarPedido(req, res, next) {
   try {
-
-    const pedido = await crearPedido(req.body);
-
     const datos = pedidoSchema.parse(req.body);
-    const pedido = crearPedido(datos);
-
-    res.status(201).json(pedido);
+    const nuevoPedido = await crearPedido(datos);
+    res.status(201).json(nuevoPedido);
   } catch (err) {
     next(err);
   }
@@ -29,11 +25,11 @@ async function obtenerHistorial(req, res, next) {
 
 async function cancelar(req, res, next) {
   try {
-    const pedido = await cancelarPedido(req.params.id);
-    if (!pedido) {
+    const pedidoCancelado = await cancelarPedido(req.params.id);
+    if (!pedidoCancelado) {
       return res.status(404).json({ error: 'Pedido no encontrado' });
     }
-    res.json(pedido);
+    res.json(pedidoCancelado);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Summary
- renombra resultado de crear pedido a `nuevoPedido`
- renombra resultado de cancelar pedido a `pedidoCancelado`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c75c2a807c832f9fe37226f4433bd0